### PR TITLE
2 criar banco de dados para os testes unitarios

### DIFF
--- a/EhBoi.Infra/EhBoi.Infra.csproj
+++ b/EhBoi.Infra/EhBoi.Infra.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="pgadmin-config\servers.json" />
+    <Compile Remove="pgadmin-config\**" />
+    <EmbeddedResource Remove="pgadmin-config\**" />
+    <None Remove="pgadmin-config\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EhBoi.Test/EhBoi.Test.csproj
+++ b/EhBoi.Test/EhBoi.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,13 +11,22 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
+  <ItemGroup>	  
+    <ProjectReference Include="..\EhBoi.Domain\EhBoi.Domain.csproj" />
+    <ProjectReference Include="..\EhBoi.Infra\EhBoi.Infra.csproj" />
   </ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+  
 
 </Project>

--- a/EhBoi.Test/TesteBase.cs
+++ b/EhBoi.Test/TesteBase.cs
@@ -1,0 +1,28 @@
+﻿using EhBoi.Infra.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EhBoi.Test
+{
+    public class TesteBase : IDisposable
+    {
+        protected ServiceProvider _serviceProvider;
+        public TesteBase()
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<EhBoiDbContext>(options =>
+            {
+                options.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            });
+
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider.Dispose();
+        }
+
+    }
+
+}

--- a/EhBoi/docker-compose.yml
+++ b/EhBoi/docker-compose.yml
@@ -38,8 +38,6 @@ services:
     - "15432:80"
     depends_on:
     - db
-    volumes:
-      - ..\EhBoi.Infra\pgadmin-config\servers.json:/pgadmin4/servers.json
     networks:
     - postgres-network
     restart: unless-stopped


### PR DESCRIPTION
Decidi usar banco em memoria por conta da simplicidade dos testes unitarios, usarei TestContainers quando for fazer os testes de integração